### PR TITLE
Allow spots without potision (to be used in manual mode)

### DIFF
--- a/examples/web/config.js
+++ b/examples/web/config.js
@@ -28,6 +28,11 @@ const core = {
             lat: 46.216177,
             lon: 7.842615
           }
+        },
+        // manual spot test
+        {
+          id: 's04',
+          label: 'Spot 4!!!',
         }
       ]
     }
@@ -57,6 +62,11 @@ const audio = {
       id: 'a03',
       spotId: 's03',
       url: './audio/03.mp3'
+    },
+    {
+      id: 'a04',
+      spotId: 's04',
+      url: './audio/04.mp3'
     }
   ],
   options: {

--- a/examples/web/index.html
+++ b/examples/web/index.html
@@ -69,10 +69,28 @@
     .active {
       background-color: yellow;
     }
+
+    .caption {
+      margin-top: 10px;
+    }
+
+    #links {
+      position: absolute;
+      top: 0;
+      right: 0;
+      padding: 10px;
+      font-weight: 800;
+    }
   </style>
 </head>
 
 <body>
+
+  <div id="links">
+    <a href="https://geoxp.mezzoforte.design/" target="_blank">Docs</a>
+    <span>|</span>
+    <a href="https://github.com/mezzo-forte-design/geoxp" target="_blank">GitHub</a>
+  </div>
   <!-- button -->
   <div>
     <button id="test-button" type="button">Test audio</button>
@@ -86,7 +104,7 @@
   <div id="simulations">
     <div id="spot-simulation">
       <button id="simulate-spot">SIMULATE SPOT POSITION</button>
-      <button id="force-spot">FORCE SPOT</button>
+      <button id="force-spot">FORCE SPOT (manual mode)</button>
       <button id="unforce-spot">UNFORCE</button>
       <label for="spot-id-input">SPOT ID</label>
       <input id="spot-id-input" type="text" placeholder="e.g. s01" />
@@ -102,6 +120,11 @@
       <label for="position-acc-input">ACCURACY (m)</label>
       <input id="position-acc-input" type="number" placeholder="e.g. 10" />
     </div>
+  </div>
+  <div class="caption">
+    <small>
+      For rules about forcing spots in manual mode, see <a href="https://geoxp.mezzoforte.design/modules/geoxp_core#manual-mode" target="_blank">this paragraph</a>.
+    </small>
   </div>
   <br>
   <hr>

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -323,7 +323,7 @@ export default class GeoXpCore {
       return 'location update not received yet';
     }
 
-    const { distance, inside } = getSpotDistances(this.lastLocation, spot, this.config.options);
+    const { distance, inside } = getSpotDistances(this.lastLocation, spot.position, this.config.options);
 
     // checks for max allowed distance
     if (distance - this.lastLocation.accuracy > inside) {
@@ -474,7 +474,8 @@ export default class GeoXpCore {
 
     // deactivate spots
     forEachSpotInPatterns(this.patterns, (pattern, spot) => {
-      const { distance, outside } = getSpotDistances(location, spot, this.config?.options);
+      if (!spot.position) return;
+      const { distance, outside } = getSpotDistances(location, spot.position, this.config?.options);
 
       if (distance > outside) {
         // spot is outside
@@ -490,7 +491,8 @@ export default class GeoXpCore {
 
     // activate new spots, prefetch incoming spots
     forEachSpotInPatterns(this.patterns, (pattern, spot) => {
-      const { distance, inside, fetch } = getSpotDistances(location, spot, this.config?.options);
+      if (!spot.position) return;
+      const { distance, inside, fetch } = getSpotDistances(location, spot.position, this.config?.options);
 
       if (distance <= inside) {
         // first time inside (if user stays in the same location, content is not repeated)
@@ -519,7 +521,8 @@ export default class GeoXpCore {
 
     // activate spots to replay or visited
     forEachSpotInPatterns(this.patterns, (pattern, spot) => {
-      const { distance, inside } = getSpotDistances(location, spot, this.config?.options);
+      if (!spot.position) return;
+      const { distance, inside } = getSpotDistances(location, spot.position, this.config?.options);
 
       if (distance <= inside) {
         // first time inside (if user stays in the same location, content is not repeated)
@@ -541,7 +544,8 @@ export default class GeoXpCore {
 
     // sets spots first time inside (if user stays in the same location, content is not repeated)
     forEachSpotInPatterns(this.patterns, (pattern, spot) => {
-      const { distance, inside } = getSpotDistances(location, spot, this.config?.options);
+      if (!spot.position) return;
+      const { distance, inside } = getSpotDistances(location, spot.position, this.config?.options);
 
       if (distance <= inside) {
         // first time inside (if user stays in the same location, content is not repeated)

--- a/packages/core/src/types/common.ts
+++ b/packages/core/src/types/common.ts
@@ -45,7 +45,7 @@ export interface GeoXpSpot {
   label?: string;
 
   /** Spot position */
-  position: GeoXpSpotPosition;
+  position?: GeoXpSpotPosition;
 
   /** Spot can activacte only after this spot id has been visited */
   after?: string;

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -13,7 +13,7 @@ import {
   DEFAULT_FETCH,
   DEFAULT_ACCURACY,
 } from './constants';
-import { GeoXpGeolocation, GeoXpSpot } from './types/common';
+import { GeoXpGeolocation, GeoXpSpot, GeoXpSpotPosition } from './types/common';
 
 export const sanitiseConfig = (config: GeoXpCoreConfig): SanitisedConfig => ({
   ...config,
@@ -116,11 +116,9 @@ export const calcGeoDistance = (
 
 export const getSpotDistances = (
   location: GeoXpGeolocation,
-  spot: GeoXpSpot,
+  position: GeoXpSpotPosition,
   options: GeoXpCoreConfigOptions
 ) => {
-  const position = spot.position;
-
   // calc distance
   const distance = calcGeoDistance(location, position);
 


### PR DESCRIPTION
# 📑 Changelog
### ➕ Added
* manual spot to web example

### 🪛 Changed
* improved documentation for manual mode

### 🩹 Fixed
* make spot position optional to enable manual spots configuration
