### PR TITLE
Use deep copy for config objects

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -149,7 +149,7 @@ export default class GeoXpCore {
 
       if (pattern) {
         // pattern alredy exists, change cfg info
-        pattern.cfg = cfg;
+        pattern.cfg = JSON.parse(JSON.stringify(cfg)) as GeoXpCorePattern['cfg'];
 
         // reload visited spots from storage
         if (this._getStoredVisitedSpots) {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -15,40 +15,43 @@ import {
 } from './constants';
 import { GeoXpGeolocation, GeoXpSpot, GeoXpSpotPosition } from './types/common';
 
-export const sanitiseConfig = (config: GeoXpCoreConfig): SanitisedConfig => ({
-  ...config,
-  options: {
-    defaultRadius: sanitiseNumber({
-      inputLabel: 'defaultRadius',
-      inputValue: config.options?.defaultRadius,
-      defaultValue: DEFAULT_RADIUS,
-      excludeZero: true,
-    }),
-    defaultDeadband: sanitiseNumber({
-      inputLabel: 'defaultDeadband',
-      inputValue: config.options?.defaultDeadband,
-      defaultValue: DEFAULT_DEADBAND,
-      excludeZero: true,
-    }),
-    defaultFetch: sanitiseNumber({
-      inputLabel: 'defaultFetch',
-      inputValue: config.options?.defaultFetch,
-      defaultValue: DEFAULT_FETCH,
-      excludeZero: true,
-    }),
-    accuracy: sanitiseNumber({
-      inputLabel: 'accuracy',
-      inputValue: config.options?.accuracy,
-      defaultValue: DEFAULT_ACCURACY,
-      excludeZero: true,
-    }),
-    visitedFilter: sanitiseNumber({
-      inputLabel: 'visitedFilter time',
-      inputValue: config.options?.visitedFilter,
-      defaultValue: DEFAULT_VISITED_FILTER_TIME,
-    }),
-  },
-});
+export const sanitiseConfig = (config: GeoXpCoreConfig): SanitisedConfig => {
+  const clonedConfig = JSON.parse(JSON.stringify(config)) as GeoXpCoreConfig;
+  return {
+    ...clonedConfig,
+    options: {
+      defaultRadius: sanitiseNumber({
+        inputLabel: 'defaultRadius',
+        inputValue: clonedConfig.options?.defaultRadius,
+        defaultValue: DEFAULT_RADIUS,
+        excludeZero: true,
+      }),
+      defaultDeadband: sanitiseNumber({
+        inputLabel: 'defaultDeadband',
+        inputValue: clonedConfig.options?.defaultDeadband,
+        defaultValue: DEFAULT_DEADBAND,
+        excludeZero: true,
+      }),
+      defaultFetch: sanitiseNumber({
+        inputLabel: 'defaultFetch',
+        inputValue: clonedConfig.options?.defaultFetch,
+        defaultValue: DEFAULT_FETCH,
+        excludeZero: true,
+      }),
+      accuracy: sanitiseNumber({
+        inputLabel: 'accuracy',
+        inputValue: clonedConfig.options?.accuracy,
+        defaultValue: DEFAULT_ACCURACY,
+        excludeZero: true,
+      }),
+      visitedFilter: sanitiseNumber({
+        inputLabel: 'visitedFilter time',
+        inputValue: clonedConfig.options?.visitedFilter,
+        defaultValue: DEFAULT_VISITED_FILTER_TIME,
+      }),
+    },
+  };
+};
 
 export const getSpotFromRef = (
   patterns: Map<string, GeoXpCorePattern>,

--- a/packages/web-audio/index.ts
+++ b/packages/web-audio/index.ts
@@ -8,7 +8,7 @@ import type { Listener, Key } from '@geoxp/utils';
 import { Howl, Howler } from 'howler';
 import { EventEmitter } from 'events';
 import { isIOS, hasWebAudio, sanitiseConfig } from './src/utils';
-import type { GeoXpWebAudioConfig, SanitisedConfig } from './src/types/config';
+import type { GeoXpWebAudioConfig, SanitisedConfig, GeoXpWebAudioConfigSound } from './src/types/config';
 import type { GeoXpWebAudioEvent, GeoXpWebAudioSound } from './src/types/module';
 
 // use webAudio instead of html5 audio only on iOS capable devices
@@ -194,14 +194,15 @@ export default class GeoXpWebAudio {
 
     // for each sound related to spot
     soundsCfg.forEach((soundCfg) => {
+      const clonedSoundCfg = JSON.parse(JSON.stringify(soundCfg)) as GeoXpWebAudioConfigSound;
       // creates new sound
       const sound = {
-        cfg: soundCfg,
+        cfg: clonedSoundCfg,
         shouldPlay: autoPlay,
         shouldStop: false,
         isFadingOut: false,
         audio: new Howl({
-          src: [soundCfg.url],
+          src: [clonedSoundCfg.url],
           html5: !USE_WEBAUDIO,
         }),
         // expose autoplaySounds in the event payload for easier access by listeners
@@ -209,7 +210,7 @@ export default class GeoXpWebAudio {
       };
 
       // sound id = spot id + cfg id
-      const id = `${soundCfg.spotId}-${soundCfg.id}`;
+      const id = `${clonedSoundCfg.spotId}-${clonedSoundCfg.id}`;
 
       // save reference to buffer
       this.buffer.set(id, sound);

--- a/packages/web-audio/src/utils.ts
+++ b/packages/web-audio/src/utils.ts
@@ -10,6 +10,8 @@ import defaultTestSound from './audio/test.mp3';
 import { sanitiseNumber } from '@geoxp/utils';
 
 export const sanitiseConfig = (config: GeoXpWebAudioConfig): SanitisedConfig => {
+  const clonedConfig = JSON.parse(JSON.stringify(config)) as GeoXpWebAudioConfig;
+
   const defaultOptions = {
     test: defaultTestSound,
     silence: defaultSilenceSound,
@@ -18,21 +20,21 @@ export const sanitiseConfig = (config: GeoXpWebAudioConfig): SanitisedConfig => 
 
   const sanitisedOptions = {
     ...defaultOptions,
-    ...config.options,
+    ...clonedConfig.options,
     fadeInTime: sanitiseNumber({
       inputLabel: 'fadeInTime',
-      inputValue: config.options?.fadeInTime,
+      inputValue: clonedConfig.options?.fadeInTime,
       defaultValue: DEFAULT_FADE_IN_TIME,
     }),
     fadeOutTime: sanitiseNumber({
       inputLabel: 'fadeOutTime',
-      inputValue: config.options?.fadeOutTime,
+      inputValue: clonedConfig.options?.fadeOutTime,
       defaultValue: DEFAULT_FADE_OUT_TIME,
     }),
   };
 
   return {
-    ...config,
+    ...clonedConfig,
     options: sanitisedOptions,
   };
 };

--- a/packages/web-geolocation/src/utils.ts
+++ b/packages/web-geolocation/src/utils.ts
@@ -8,16 +8,17 @@ import { DEFAULT_HIGH_ACCURACY, DEFAULT_MAX_AGE, DEFAULT_TIMEOUT } from './const
 import { GeoXpWebGeolocationConfig, SanitisedConfig } from './types/config';
 
 export const sanitiseConfig = (config?: GeoXpWebGeolocationConfig): SanitisedConfig => {
+  const clonedConfig = JSON.parse(JSON.stringify(config)) as GeoXpWebGeolocationConfig;
   const santised = {
-    enableHighAccuracy: config?.enableHighAccuracy ?? DEFAULT_HIGH_ACCURACY,
+    enableHighAccuracy: clonedConfig?.enableHighAccuracy ?? DEFAULT_HIGH_ACCURACY,
     maximumAge: sanitiseNumber({
       inputLabel: 'maximumAge',
-      inputValue: config?.maximumAge,
+      inputValue: clonedConfig?.maximumAge,
       defaultValue: DEFAULT_MAX_AGE,
     }),
     timeout: sanitiseNumber({
       inputLabel: 'timeout',
-      inputValue: config?.timeout,
+      inputValue: clonedConfig?.timeout,
       defaultValue: DEFAULT_TIMEOUT,
     }),
   };

--- a/packages/web-storage/src/utils.ts
+++ b/packages/web-storage/src/utils.ts
@@ -12,18 +12,25 @@ import {
 } from './constants';
 import { GeoXpWebStorageConfig, SanitisedConfig } from './types/config';
 
-export const sanitiseConfig = (config?: GeoXpWebStorageConfig): SanitisedConfig => ({
-  cookiePrefix: config?.cookiePrefix ?? DEFAULT_COOKIE_PREFIX,
-  expiration: sanitiseNumber({
-    inputLabel: 'cookie expiration (minutes)',
-    inputValue: config?.expiration,
-    defaultValue: DEFAULT_COOKIE_EXPIRATION,
-  }),
-  deleteOnLastSpot:
-    config?.deleteOnLastSpot !== undefined ? config.deleteOnLastSpot : DEFAULT_DELETE_ON_LAST_SPOT,
-  deleteOnCompletion:
-    config?.deleteOnCompletion !== undefined ? config.deleteOnCompletion : DEFAULT_DELETE_ON_COMPLETION,
-});
+export const sanitiseConfig = (config?: GeoXpWebStorageConfig): SanitisedConfig => {
+  const clonedConfig = JSON.parse(JSON.stringify(config)) as GeoXpWebStorageConfig;
+  return {
+    cookiePrefix: clonedConfig?.cookiePrefix ?? DEFAULT_COOKIE_PREFIX,
+    expiration: sanitiseNumber({
+      inputLabel: 'cookie expiration (minutes)',
+      inputValue: clonedConfig?.expiration,
+      defaultValue: DEFAULT_COOKIE_EXPIRATION,
+    }),
+    deleteOnLastSpot:
+      clonedConfig?.deleteOnLastSpot !== undefined
+        ? clonedConfig.deleteOnLastSpot
+        : DEFAULT_DELETE_ON_LAST_SPOT,
+    deleteOnCompletion:
+      clonedConfig?.deleteOnCompletion !== undefined
+        ? clonedConfig.deleteOnCompletion
+        : DEFAULT_DELETE_ON_COMPLETION,
+  };
+};
 
 export const setCookie = (name: string, value: unknown, expiration: number) => {
   try {


### PR DESCRIPTION
# 📑 Changelog
### 🪛 Changed
* deep copy config objects to avoid changes in original reference
